### PR TITLE
Placeholder image sizing fix

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -260,7 +260,7 @@ button,
 }
 
 /* Image block */
-.image-block img {
+.image-block :is(img, .placeholder-image) {
   height: 100%;
 }
 
@@ -500,6 +500,10 @@ a {
 .media-block.column > div {
   max-width: 100%;
   width: 100%;
+}
+
+.media-block .placeholder-image {
+  height: 100%;
 }
 
 /* Quantity selector block */

--- a/blocks/product-medias.liquid
+++ b/blocks/product-medias.liquid
@@ -49,7 +49,7 @@
   {%- endfor -%}
 
   {%- if target == blank -%}
-    <div class="placeholder-image">
+    <div class="placeholder-image" style="aspect-ratio:1;">
       {{ 'product-apparel-2' | placeholder_svg_tag: 'image-placeholder-svg' }}
     </div>
   {%- endif -%}
@@ -76,11 +76,8 @@
       "id": "size",
       "label": "Size",
       "default": {
-        "width": "auto",
-
-        "@media (--mobile)": {
-          "width": "100%"
-        }
+        "width": "100%",
+        "flex-grow": "1"
       }
     },
     {


### PR DESCRIPTION
Placeholder sizing should be now applied properly. 

When playing with the image block size, it would sometimes overflow the svg outside the bounds of the container div. 
This helps with making sure the placeholder is always covering the area properly. 

Contains doesn't work on placeholders atm. Seem likes we would need to tweak the `preservedAspectRatio` attribute on the svg itself but we don't have control over it. So i think it's ok for now to keep it as is. 