### PR TITLE
Removing duplicate viewport meta and cdn preconnect

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -8,9 +8,6 @@
     <link rel="canonical" href="{{ canonical_url }}">
     <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="preconnect" href="https://cdn.shopify.com">
-
     <title>
       {{ page_title }}
       {%- if current_tags %} &ndash; tagged "{{ current_tags | join: ', ' }}"{% endif -%}


### PR DESCRIPTION
Note: the remaining preconnect has crossorigin whereas the one that this commit removes did not.