### PR TITLE
Rename context to closest

### DIFF
--- a/blocks/buy-buttons.liquid
+++ b/blocks/buy-buttons.liquid
@@ -126,7 +126,7 @@
   "presets": [
     { 
       "name": "Product (buy buttons)",
-      "settings": { "product": "{{ context.product }}" }
+      "settings": { "product": "{{ closest.product }}" }
     }
   ]
 }

--- a/blocks/collection-card.liquid
+++ b/blocks/collection-card.liquid
@@ -66,13 +66,13 @@
         {
           "type": "image",
           "settings": {
-            "image": "{{ context.collection.image }}"
+            "image": "{{ closest.collection.image }}"
           }
         },
         {
           "type": "collection-title",
           "settings": {
-            "collection": "{{ context.collection }}",
+            "collection": "{{ closest.collection }}",
             "heading_size": "h4"
           }
         }

--- a/blocks/collection-title.liquid
+++ b/blocks/collection-title.liquid
@@ -85,7 +85,7 @@
     {
       "name": "Collection (title)",
       "settings": {
-        "collection": "{{ context.collection }}"
+        "collection": "{{ closest.collection }}"
       }
     }
   ]

--- a/blocks/price.liquid
+++ b/blocks/price.liquid
@@ -51,7 +51,7 @@
     {
       "name": "Product (price)",
       "settings": {
-        "product": "{{ context.product }}"
+        "product": "{{ closest.product }}"
       }
     }
   ]

--- a/blocks/product-card.liquid
+++ b/blocks/product-card.liquid
@@ -67,21 +67,21 @@
         {
           "type": "product-medias",
           "settings": {
-            "product": "{{ context.product }}",
+            "product": "{{ closest.product }}",
             "media_featured": true
           }
         },
         {
           "type": "product-title",
           "settings": {
-            "product": "{{ context.product }}",
+            "product": "{{ closest.product }}",
             "heading_size": "h5"
           }
         },
         {
           "type": "price",
           "settings": {
-            "product": "{{ context.product }}"
+            "product": "{{ closest.product }}"
           }
         }
       ]

--- a/blocks/product-description.liquid
+++ b/blocks/product-description.liquid
@@ -36,7 +36,7 @@
   "presets": [
     {
       "name": "Product (description)",
-      "settings": { "product": "{{ context.product }}" }
+      "settings": { "product": "{{ closest.product }}" }
     }
   ]
 }

--- a/blocks/product-grid.liquid
+++ b/blocks/product-grid.liquid
@@ -15,7 +15,7 @@
     >
       {% for product in products limit: block.settings.products_to_show %}
         <li>
-          {% content_for "block", type: "product-card", id: "product-grid-item", context.product: product %}
+          {% content_for "block", type: "product-card", id: "product-grid-item", closest.product: product %}
         </li>
       {% endfor %}
     </ul>
@@ -77,27 +77,27 @@
           "type": "product-card",
           "static": true,
           "settings": {
-            "product": "{{ context.product }}"
+            "product": "{{ closest.product }}"
           },
           "blocks": [
             {
               "type": "product-medias",
               "settings": {
-                "product": "{{ context.product }}",
+                "product": "{{ closest.product }}",
                 "media_featured": true
               }
             },
             {
               "type": "product-title",
               "settings": {
-                "product": "{{ context.product }}",
+                "product": "{{ closest.product }}",
                 "heading_size": "h5"
               }
             },
             {
               "type": "price",
               "settings": {
-                "product": "{{ context.product }}"
+                "product": "{{ closest.product }}"
               }
             }
           ]

--- a/blocks/product-medias.liquid
+++ b/blocks/product-medias.liquid
@@ -92,7 +92,7 @@
     {
       "name": "Product (media)",
       "settings": {
-        "product": "{{ context.product }}"
+        "product": "{{ closest.product }}"
       }
     }
   ]

--- a/blocks/product-title.liquid
+++ b/blocks/product-title.liquid
@@ -85,7 +85,7 @@
     {
       "name": "Product (title)",
       "settings": {
-        "product": "{{ context.product }}"
+        "product": "{{ closest.product }}"
       }
     }
   ]

--- a/blocks/quantity-selector.liquid
+++ b/blocks/quantity-selector.liquid
@@ -59,7 +59,7 @@
   "presets": [
     {
       "name": "Product (quantity select)",
-      "settings": { "product": "{{ context.product }}" }
+      "settings": { "product": "{{ closest.product }}" }
     }
   ]
 }

--- a/blocks/variant-picker.liquid
+++ b/blocks/variant-picker.liquid
@@ -86,7 +86,7 @@
   "presets": [
     {
       "name": "Product (variant picker)",
-      "settings": { "product": "{{ context.product }}" }
+      "settings": { "product": "{{ closest.product }}" }
     }
   ]
 }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2,7 +2,7 @@
   {
     "name": "theme_info",
     "theme_name": "Reference theme",
-    "theme_version": "0.4.1",
+    "theme_version": "0.4.2",
     "theme_author": "Shopify",
     "theme_documentation_url": "https://help.shopify.com/manual/online-store/themes",
     "theme_support_url": "https://support.shopify.com/"

--- a/sections/custom-section.liquid
+++ b/sections/custom-section.liquid
@@ -343,7 +343,7 @@
                 {
                   "type": "image",
                   "settings": {
-                    "image": "{{ context.collection.image }}",
+                    "image": "{{ closest.collection.image }}",
                     "object_fit": "cover",
                     "spacing": {},
                     "size": {}
@@ -352,7 +352,7 @@
                 {
                   "type": "collection-title",
                   "settings": {
-                    "collection": "{{ context.collection}}",
+                    "collection": "{{ closest.collection}}",
                     "heading_size": "h4",
                     "alignment": "start"
                   }
@@ -365,7 +365,7 @@
                 {
                   "type": "image",
                   "settings": {
-                    "image": "{{ context.collection.image }}",
+                    "image": "{{ closest.collection.image }}",
                     "object_fit": "cover",
                     "spacing": {},
                     "size": {}
@@ -374,7 +374,7 @@
                 {
                   "type": "collection-title",
                   "settings": {
-                    "collection": "{{ context.collection }}",
+                    "collection": "{{ closest.collection }}",
                     "heading_size": "h4",
                     "alignment": "start"
                   }
@@ -387,7 +387,7 @@
                 {
                   "type": "image",
                   "settings": {
-                    "image": "{{ context.collection.image }}",
+                    "image": "{{ closest.collection.image }}",
                     "object_fit": "cover",
                     "spacing": {},
                     "size": {}
@@ -396,7 +396,7 @@
                 {
                   "type": "collection-title",
                   "settings": {
-                    "collection": "{{ context.collection }}",
+                    "collection": "{{ closest.collection }}",
                     "heading_size": "h4",
                     "alignment": "start"
                   }
@@ -884,27 +884,27 @@
               "type": "product-card",
               "static": true,
               "settings": {
-                "product": "{{ context.product }}"
+                "product": "{{ closest.product }}"
               },
               "blocks": [
                 {
                   "type": "product-medias",
                   "settings": {
-                    "product": "{{ context.product }}",
+                    "product": "{{ closest.product }}",
                     "media_featured": true
                   }
                 },
                 {
                   "type": "product-title",
                   "settings": {
-                    "product": "{{ context.product }}",
+                    "product": "{{ closest.product }}",
                     "heading_size": "h5"
                   }
                 },
                 {
                   "type": "price",
                   "settings": {
-                    "product": "{{ context.product }}"
+                    "product": "{{ closest.product }}"
                   }
                 }
               ]

--- a/sections/main-collection.liquid
+++ b/sections/main-collection.liquid
@@ -11,7 +11,7 @@
       <ul class="product-grid product-grid--{{ section.id }}">
         {% for product in collection.products %}
           <li>
-            {% content_for "block", type: "product-card", id: "collection-product-card", context.product: product %}
+            {% content_for "block", type: "product-card", id: "collection-product-card", closest.product: product %}
           </li>
         {% endfor %}
       </ul>

--- a/sections/main-list-collections.liquid
+++ b/sections/main-list-collections.liquid
@@ -4,7 +4,7 @@
   <ul class="product-grid product-grid--{{ section.id }}">
     {% for collection in collections %}
       <li>
-        {% content_for "block", type: "collection-card", id: "collection-card", context.collection: collection %}
+        {% content_for "block", type: "collection-card", id: "collection-card", closest.collection: collection %}
       </li>
     {% endfor %}
   </ul>

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -6,7 +6,7 @@
         "heading_mqAgUH": {
           "type": "heading",
           "settings": {
-            "heading": "{{ context.collection.title }}",
+            "heading": "{{ closest.collection.title }}",
             "heading_size": "h1",
             "alignment": "start",
             "size": {
@@ -35,27 +35,27 @@
           "type": "product-card",
           "static": true,
           "settings": {
-            "product": "{{ context.product }}"
+            "product": "{{ closest.product }}"
           },
           "blocks": {
             "product_medias_Gawh7G": {
               "type": "product-medias",
               "settings": {
-                "product": "{{ context.product }}",
+                "product": "{{ closest.product }}",
                 "media_featured": true,
               }
             },
             "title_zGnXr7": {
               "type": "product-title",
               "settings": {
-                "product": "{{ context.product }}",
+                "product": "{{ closest.product }}",
                 "heading_size": "h5",
               }
             },
             "price_fiTWdm": {
               "type": "price",
               "settings": {
-                "product": "{{ context.product }}"
+                "product": "{{ closest.product }}"
               }
             }
           },

--- a/templates/index.json
+++ b/templates/index.json
@@ -206,7 +206,7 @@
               "type": "product-card",
               "static": true,
               "settings": {
-                "product": "{{ context.product }}",
+                "product": "{{ closest.product }}",
                 "size": {
                 },
                 "spacing": {
@@ -218,7 +218,7 @@
                 "product_medias_6MgirX": {
                   "type": "product-medias",
                   "settings": {
-                    "product": "{{ context.product }}",
+                    "product": "{{ closest.product }}",
                     "media_featured": true,
                     "size": {
                     },
@@ -229,7 +229,7 @@
                 "product_title_rxBEdE": {
                   "type": "product-title",
                   "settings": {
-                    "product": "{{ context.product }}",
+                    "product": "{{ closest.product }}",
                     "heading_size": "h5",
                     "alignment": "start",
                     "size": {
@@ -241,7 +241,7 @@
                 "price_RhcUJE": {
                   "type": "price",
                   "settings": {
-                    "product": "{{ context.product }}",
+                    "product": "{{ closest.product }}",
                     "size": {
                     },
                     "spacing": {
@@ -324,7 +324,7 @@
                 "image_JPFbHD": {
                   "type": "image",
                   "settings": {
-                    "image": "{{ context.collection.image }}",
+                    "image": "{{ closest.collection.image }}",
                     "object_fit": "cover",
                     "spacing": {
                     },
@@ -335,7 +335,7 @@
                 "collection_title_6TbyVH": {
                   "type": "collection-title",
                   "settings": {
-                    "collection": "{{ context.collection }}",
+                    "collection": "{{ closest.collection }}",
                     "heading_size": "h4",
                     "alignment": "start",
                     "size": {
@@ -365,7 +365,7 @@
                 "image_CPj9m9": {
                   "type": "image",
                   "settings": {
-                    "image": "{{ context.collection.image }}",
+                    "image": "{{ closest.collection.image }}",
                     "object_fit": "cover",
                     "spacing": {
                     },
@@ -376,7 +376,7 @@
                 "collection_title_wnEkaU": {
                   "type": "collection-title",
                   "settings": {
-                    "collection": "{{ context.collection }}",
+                    "collection": "{{ closest.collection }}",
                     "heading_size": "h4",
                     "alignment": "start",
                     "size": {
@@ -406,7 +406,7 @@
                 "image_NzHXGX": {
                   "type": "image",
                   "settings": {
-                    "image": "{{ context.collection.image }}",
+                    "image": "{{ closest.collection.image }}",
                     "object_fit": "cover",
                     "spacing": {
                     },
@@ -417,7 +417,7 @@
                 "collection_title_3CnknM": {
                   "type": "collection-title",
                   "settings": {
-                    "collection": "{{ context.collection }}",
+                    "collection": "{{ closest.collection }}",
                     "heading_size": "h4",
                     "alignment": "start",
                     "size": {
@@ -649,7 +649,7 @@
                     "image_i6GYY7": {
                       "type": "image",
                       "settings": {
-                        "image": "{{ context.collection.image }}",
+                        "image": "{{ closest.collection.image }}",
                         "object_fit": "cover",
                         "spacing": {
                         },
@@ -660,7 +660,7 @@
                     "collection_title_gjenUt": {
                       "type": "collection-title",
                       "settings": {
-                        "collection": "{{ context.collection }}",
+                        "collection": "{{ closest.collection }}",
                         "heading_size": "h4",
                         "alignment": "start",
                         "size": {
@@ -696,7 +696,7 @@
                 "image_wHhybY": {
                   "type": "image",
                   "settings": {
-                    "image": "{{ context.collection.image }}",
+                    "image": "{{ closest.collection.image }}",
                     "object_fit": "cover",
                     "spacing": {
                     },
@@ -707,7 +707,7 @@
                 "collection_title_eqPK3z": {
                   "type": "collection-title",
                   "settings": {
-                    "collection": "{{ context.collection }}",
+                    "collection": "{{ closest.collection }}",
                     "heading_size": "h4",
                     "alignment": "start",
                     "size": {

--- a/templates/list-collections.json
+++ b/templates/list-collections.json
@@ -35,20 +35,20 @@
           "type": "collection-card",
           "static": true,
           "settings": {
-            "product": "{{ context.collection }}"
+            "product": "{{ closest.collection }}"
           },
           "blocks": {
             "collection-image": {
               "type": "image",
               "settings": {
-                "image": "{{ context.collection.image }}",
+                "image": "{{ closest.collection.image }}",
                 "media_featured": true
               }
             },
             "collection-title": {
               "type": "collection-title",
               "settings": {
-                "product": "{{ context.collection }}",
+                "product": "{{ closest.collection }}",
                 "heading_size": "h4"
               }
             }

--- a/templates/product.json
+++ b/templates/product.json
@@ -6,7 +6,7 @@
         "9c8f7c42-604a-41de-a594-12f7c7f0e653": {
           "type": "product-medias",
           "settings": {
-            "product": "{{ context.product }}",
+            "product": "{{ closest.product }}",
             "media_featured": true,
             "size": {
               "width": "100%",
@@ -32,7 +32,7 @@
             "8e624812-3736-4121-9762-3bb2c48e1b7c": {
               "type": "text",
               "settings": {
-                "text": "<p>{{ context.product.vendor }}<\/p>",
+                "text": "<p>{{ closest.product.vendor }}<\/p>",
                 "text_style": "text-block-caption",
                 "alignment": "start"
               }
@@ -40,7 +40,7 @@
             "product-title_MgtBgC": {
               "type": "product-title",
               "settings": {
-                "product": "{{ context.product }}",
+                "product": "{{ closest.product }}",
                 "heading_size": "h1",
                 "alignment": "start"
               }
@@ -48,25 +48,25 @@
             "85c04f16-a58b-4d58-bc70-ad8f9d1e75a3": {
               "type": "price",
               "settings": {
-                "product": "{{ context.product }}"
+                "product": "{{ closest.product }}"
               }
             },
             "0ab4dad4-d9a4-4064-8512-5d6974e32100": {
               "type": "variant-picker",
               "settings": {
-                "product": "{{ context.product }}"
+                "product": "{{ closest.product }}"
               }
             },
             "13857f6b-f089-4d09-8bf0-f55ec052560d": {
               "type": "quantity-selector",
               "settings": {
-                "product": "{{ context.product }}"
+                "product": "{{ closest.product }}"
               }
             },
             "7e6064f3-e925-4883-b434-2d96eb09a467": {
               "type": "buy-buttons",
               "settings": {
-                "product": "{{ context.product }}",
+                "product": "{{ closest.product }}",
                 "show_dynamic_checkout": true,
                 "spacing": {
                   "padding": "15px 0"
@@ -76,7 +76,7 @@
             "41c0675b-741c-4bc1-8edb-5291a98632e6": {
               "type": "product-description",
               "settings": {
-                "product": "{{ context.product }}"
+                "product": "{{ closest.product }}"
               }
             },
             "group_a3Nwet": {


### PR DESCRIPTION
We are renaming context to closest in Dynamic Sources to avoid potential conflicts and build sustainably in the future. 

For reference, here are examples of context usage in the theme code, and how they should appear once you rename to closest:
1. With content_for liquid tag
```liquid
// Current Usage:
{% content_for "blocks", context.product: product %}

// Updated Usage:
{% content_for "blocks", closest.product: product %}
```

2. In json template data and presets

```liquid
// Current Usage:
{{ context.product }}

// Updated Usage:
{{ closest.product }}
```

Follow the docs for more details: 
https://shopify.dev/docs/storefronts/themes/architecture/blocks/theme-blocks/dynamic-sources